### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Pageredirect/Form/Admin/Form/Setting/CustomRedirect.php
+++ b/CRM/Pageredirect/Form/Admin/Form/Setting/CustomRedirect.php
@@ -36,7 +36,7 @@ class CRM_Pageredirect_Form_Admin_Form_Setting_CustomRedirect extends CRM_Admin_
         'id' => $fields['pageredirect_default_contribution_page_id']
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       return array('pageredirect_default_contribution_page_id' => E::ts('Please select a valid enabled page'));
     }
     return TRUE;

--- a/pageredirect.php
+++ b/pageredirect.php
@@ -76,7 +76,7 @@ function pageredirect_civicrm_unhandled_exception($exception) {
  * @param $id
  * @param $params
  * @throws CRM_Core_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function pageredirect_civicrm_pre($op, $objectName, $id, &$params) {
   if($objectName == 'ContributionPage') {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.